### PR TITLE
Readme updates for Azure Architecture Center changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,109 @@
-# Red Dog Demo - Container Apps Deployment
+# Red Dog Demo: Azure Container Apps Deployment
 
 ## Background
 
-This repository leverages the [reddog applicaton codebase](https://github.com/Azure/reddog-code) and was created to help users deploy a comprehensive, microservice-based sample application to Azure Container Apps. 
+This repository leverages the [Reddog codebase](https://github.com/Azure/reddog-code) and was created to help users deploy a comprehensive, microservice-based sample application to Azure Container Apps. 
 
-[Azure Container Apps](https://azure.microsoft.com/en-us/services/container-apps/)* is a fully managed serverless container service for building and deploying modern apps at scale. It enables developers to deploy containerized apps without managing complex infrastructure. The reddog microservices were built using the Distributed Application Runtime (Dapr), which is provided out-of-the-box in Azure Container Apps. In addition to Dapr support, Container Apps also provides a managed Kubernetes Event Driven Autoscaling (KEDA) experience. Through the abstraction of infrastructure management and the incorporation of open source technology, Azure Container Apps provides an ideal target for the deployment of the reddog application. If you are interested in how Azure Container Apps compares to other container hosting options in Azure, visit the Azure Container Apps [documentation](https://docs.microsoft.com/en-us/azure/container-apps/compare-options)
+[Azure Container Apps](https://azure.microsoft.com/en-us/services/container-apps/) (Preview) is a fully managed serverless container offering for building and deploying modern apps at scale. It enables developers to deploy containerized apps without managing complex infrastructure like kubernetes clusters. It leverages Azure Container Apps integration with a managed version of the [Distributed Application Runtime (Dapr)](https://dapr.io/). Dapr is an open source project that helps developers with the inherent challenges presented by distributed applications, such as state management and service invocation. Container Apps also provides a managed version of [Kubernetes Event Driven Autoscaling (KEDA)](https://keda.sh/). KEDA allows your containers to autoscale based on incoming events from external services such Azure Service Bus and Redis.
 
-*Please note that Azure Container Apps is currently in Public Preview and therefore is not recommended for Production workloads
+To explore how Azure Container Apps compares to other container hosting options in Azure, see [Comparing Container Apps with other Azure container options](/azure/container-apps/compare-options). Note that Azure Container Apps is currently in Public Preview and so not recommended for production workloads. 
 
 ## Architecture
 
-The architecture is comprised of a single Container Apps Environment that hosts ten respective Container Apps. While Dapr provides flexibility around the specific component implementations leveraged for the various building blocks, this demo is opinionated. There are also a few services that make use of KEDA scale rules. 
+The architecture is comprised of a single Container Apps Environment that hosts ten .NET Core microservice applications. The .NET Core Dapr SDK is used to integrate with Azure resources through PubSub, State and Binding building blocks and while Dapr typically provides flexibility around the component implementations, this solution is opinionated. The services also make use of KEDA scale rules to allow for scaling based on event triggers as well as scale to zero scenarios.
 
 ![Architecture diagram](assets/reddog-containerapps.png)
 
-This repository leverages bicep templates in order to execute the deployment of the Reddog applicaton and the supporting Azure Infrastructure. Bicep is a Domain Specific Language (DSL) for deploying Azure resources declaratively and provides a transparent abstraction over ARM and ARM templates.  
-
-### Infrastructure Components
-
-#### Resource Group
-A logical container which holds all resources needed to run the above solution in Azure
-
-#### Container App Environment 
-The services in this solution are deployed to a single Container App environment, which acts as a secure boundary around groups of container apps
-
-#### Azure Cosmos DB 
-Microsoft's NoSQL multi-model managed database as a service offering which is used as the Dapr State Store component implementation for the Loyalty Service
-
-#### Azure Cache for Redis 
-A distributed, in-memory, scalable solution providing super-fast data access which is used as the Dapr State Store component implementation for the Makeline Service
-
-#### Azure Service Bus 
-A fully managed enterprise message broker with message queues and publish-subscribe topics used as the Dapr PubSub component implementation. This component is leveraged by multiple services, with the Order Service publishing messages to four other services in the application: Makelike, Accounting, Loyalty and Receipt
-
-#### Azure SQL DB 
-A member of the Azure SQL family, Azure SQL supports modern cloud applications on an intelligent, managed database service. This resource is created for the Accounting Service, which makes use of EF Core for interfacing with the DB. 
-
-#### Azure Blob Storage 
-Azure Blob storage is optimized for storing massive amounts of unstructured data. Unstructured data is data that doesn't adhere to a particular data model or definition, such as text or binary data. Blob storage is used by the Receipt Service via Dapr Output Bindings to store order receipts.
+This repository leverages bicep templates in order to execute the deployment of the application and the supporting Azure Infrastructure. Bicep is a Domain Specific Language (DSL) for deploying Azure resources declaratively and provides a transparent abstraction over Azure Resource Manager (ARM) and ARM templates.
 
 ### Container Apps 
 
-For insight into the various microservices and their functionality, visit the Red Dog Demo [codebase repo](https://github.com/Azure/reddog-code). This repository, however, contains an additional component that is needed to get the solution up and running on the Container Apps platform. 
+For details on the microservices and their functionality, visit the Reddog [codebase repo](https://github.com/Azure/reddog-code). Each Container Apps deployment configuration is described below including its associated Dapr components and KEDA scale rules. Please note this repository contains an additional component that is needed to get the solution up and running on Container Apps.
+
 #### Traefik 
-Traefik is a leading modern reverse proxy and load balancer that makes deploying microservices easy. Traefik integrates with your existing infrastructure components and configures itself automatically and dynamically. Container Apps currently makes use of Traefik's dynamic configuration feature in order to do path-based routing from the SPA UI as well as to enable direct calls via the rest samples
+Traefik is a leading reverse proxy and load balancer that integrates with your existing infrastructure components and configures itself automatically. The UI container app has the ability to route to backend container apps through the managed ingress capabilities (Envoy) built into the platform. For this solution, we chose to leverage Traefik's dynamic configuration feature to provide a single point of ingress and a way to invoke internal, back-end apis using the [rest-samples](./rest-samples). The alternative approach would be to enable external ingress on multiple container apps in the environment. Traefik is not necessary for all Container Apps ingress configurations but enables sub-domain routing capabilities which are not supported in the service today, as all container apps in the environment are deployed to a single domain.
+
 
 | Service          | Ingress |  Dapr Component(s) | KEDA Scale Rule(s) |
 |------------------|---------|--------------------|--------------------|
-| Traefik | External | Dapr not-enabled (soon) | HTTP |
-| UI | Internal | Dapr not-enabled (soon) | HTTP |
+| Traefik | External | Dapr not enabled | HTTP |
+| UI | Internal | Dapr not enabled | HTTP |
+| Virtual Customer | None | Service to Service Invocation | N/A |
 | Order Service | Internal | PubSub: Azure Service Bus | HTTP |
-| Accounting Service | Internal | PubSub: Azure Service Bus | Azure Service Bus Topic Length / HTTP |
+| Accounting Service | Internal | PubSub: Azure Service Bus | Azure Service Bus Topic Length, HTTP |
 | Receipt Service | Internal | PubSub: Azure Service Bus, Binding: Azure Blob | Azure Service Bus Topic Length |
 | Loyalty Service | Internal | PubSub: Azure Service Bus, State: Azure Cosmos DB | Azure Service Bus Topic Length |
-| Makeline Service | Internal | PubSub: Azure Service Bus, State: Azure Redis | Azure Service Bus Topic Length / HTTP |
-| Virtual Worker | None | Binding: Cron | n/a |
-| Virtual Customer | None | Service to Service | n/a |
+| Makeline Service | Internal | PubSub: Azure Service Bus, State: Azure Redis | Azure Service Bus Topic Length, HTTP |
+| Virtual Worker | None | Service to Service Invocation, Binding: Cron | N/A |
 
-*A tenth service, Bootstrapper, will also be executed. However, this service is run once to perform EF Core Migration and is subsequently scaled to 0 after completing the necessary scaffolding.
+>A tenth service, Bootstrapper is also executed in a Container App. This service is run once to perform the database creation and is subsequently scaled to 0 after creating the necessary objects in Azure SQL Database.
 
-## Getting Started
+## Deployment
 
-This repo contains the scripts and configurations to deploy the Red Dog Demo along with the backing Azure Resources. Simply clone the repo and execute the `run.sh` deployment script. Further details will be added soon.
+To deploy the Reddog services along with the necessary Azure Resources, clone this repo and run the following [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) commands. You will need an Azure subscription where you have permission to create a Resource Group (eg. Contributor). Alternatively you may execute the [deploy.sh](./deploy.sh) script.
+
+> Please note that Container Apps is only available in [a subset of Azure regions](https://azure.microsoft.com/en-ca/global-infrastructure/services/?products=container-apps) during Public Preview. 
+
+
+```bash
+# *nix only
+export RG="reddog"
+export LOCATION="eastus2"
+export SUB_ID="<YourSubscriptionID>"
+
+# Follow Azure CLI prompts to authenticate to the subscription of your choice
+az login
+az account set --subscription $SUB_ID
+
+# Create resource group
+az group create -n $RG -l $LOCATION
+
+# Deploy infrastructure and reddog apps
+az deployment group create -n reddog -g $RG -f ./deploy/bicep/main.bicep
+
+# Display outputs from bicep deployment
+az deployment group show -n reddog -g $RG -o json --query properties.outputs.urls.value
+```
+
+To check the status of the deployment while it is running navigate to the `Deployments` blade on the Resource Group in the Azure Portal. Deployment should take ~25 minutes and once completed, you should receive an output similar to the following.
+
+```bash
+[
+  "UI: https://reddog.whitebush-a2e52ffc.eastus2.azurecontainerapps.io",
+  "Product: https://reddog.whitebush-a2e52ffc.eastus2.azurecontainerapps.io/product",
+  "Makeline Orders (Redmond): https://reddog.whitebush-a2e52ffc.eastus2.azurecontainerapps.io/makeline/orders/Redmond",
+  "Accounting Order Metrics (Redmond): https://reddog.whitebush-a2e52ffc.eastus2.azurecontainerapps.io/accounting/OrderMetrics?StoreId=Redmond"
+]
+```
+
+Navigate to the fqdn of the UI to see the Reddog solution up and running on Container Apps! 
+
+## Delete the Deployment
+
+Clean up the deployment by deleting the single resource group that contains the Reddog infrastructure.
+
+> Warning: If you deployed additional resources inside the `reddog` Resource Group, the following command will delete all of them.
+
+```bash
+# *nix only
+export RG="reddog"
+
+az group delete --name $RG --yes --no-wait
+```
+
+## Infrastructure Components
+
+This solution uses the following components:
+
+- [Resource Groups](/azure/azure-resource-manager/management/manage-resource-groups-portal) are logical containers for Azure resources.  We use a single resource group to structure everything related to this solution in the Azure portal.
+- [Azure Container Apps](/azure/container-apps) is a fully managed serverless container service for building and deploying modern apps at scale. In this solution we hosting all of the 10 microservices on Container Apps and deploying them into a single Container App Environment, which acts as a secure boundary around the system.
+- [Azure Service Bus](/azure/service-bus-messaging/) is a fully managed enterprise message broker complete with queues and publish-subscribe topics used in this case for the Dapr PubSub component implementation. This component is leveraged by multiple services, with the Order Service publishing messages on the bus and the Makeline, Accounting, Loyalty and Receipt services subscribing to these messages.
+- [Azure CosmosDB](/azure/cosmos-db/) is a NoSQL multi-model managed database  service that is used as a Dapr State Store component for the Loyalty Service to store customer's loyalty data.
+- [Azure Cache for Redis](/azure/azure-cache-for-redis/) is a distributed, in-memory, scalable managed Redis cache. It is used as a Dapr State Store component for the Makeline Service to store data on the orders that are being processed.
+- [Azure SQL Database](/azure/azure-sql/) is an intelligent, scalable, relational database service built for the cloud. It is created for the Accounting Service, which makes use of [Entity Framework Core](/ef/core/) for interfacing with the database. The Bootstrapper Service is responsible for setting up the SQL Tables in the database and runs once before connection to the Accounting Service is established.
+- [Azure Blob Storage](/azure/storage/blobs/) is optimized for storing massive amounts of unstructured data such as text or binary files. Blob storage is used by the Receipt Service via a Dapr Output Bindings to store the order receipts.
+- [Traefik](https://traefik.io/traefik/) is a leading modern reverse proxy and load balancer that makes deploying microservices easy. In this solution we are making use of Traefik's dynamic configuration feature to do path-based routing from the UI (a Vue.js SPA) and to enable direct API calls to the backend services for testing.
+- [Azure Monitor](/azure/azure-monitor/) enables you to collect, analyze, and act on telemetry data from your Azure infrastructure environments. It is used along with [Application Insights](/azure/azure-monitor/app/app-insights-overview) to view the container logs and collect metrics from the microservices.
 
 ## Contributing
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,9 +1,17 @@
-# Linux/Mac only
+# *nix only
 export RG="reddog"
-export LOCATION="eastus"
+export LOCATION="eastus2"
+export SUB_ID="<YourSubscriptionID>"
 
+# Follow Azure CLI prompts to authenticate to your subscription of choice
+az login
+az account set --subscription $SUB_ID
+
+# Create resource group
 az group create -n $RG -l $LOCATION
 
+# Deploy all infrastructure and reddog apps
 az deployment group create -n reddog -g $RG -f ./deploy/bicep/main.bicep
 
+# Show outputs for bicep deployment
 az deployment group show -n reddog -g $RG -o json --query properties.outputs.urls.value

--- a/deploy/bicep/modules/container-apps/accounting-service.bicep
+++ b/deploy/bicep/modules/container-apps/accounting-service.bicep
@@ -5,8 +5,6 @@ param sqlServerName string
 param sqlDatabaseName string
 param sqlAdminLogin string
 param sqlAdminLoginPassword string
-//param sbRootConnectionString string
-//param sqlConnectionString string
 
 resource cappsEnv 'Microsoft.Web/kubeEnvironments@2021-03-01' existing = {
   name: containerAppsEnvName

--- a/rest-samples/order-service.rest
+++ b/rest-samples/order-service.rest
@@ -1,4 +1,4 @@
-@order-service = reddog.proudpebble-f0d0d779.canadacentral.azurecontainerapps.io
+@order-service = reddog.whitebush-a2e52ffc.eastus2.azurecontainerapps.io
 @storeId = Redmond
 
 ### Create an order via order-service POST


### PR DESCRIPTION
Updates for Reddog Container Apps in the  Azure Architecture Center:
- Readme updates
- cleanup script
- Traefik note on architectural decision 