### PR TITLE
Uplift UI min replicas from 0 to 1

### DIFF
--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -18,6 +18,9 @@ param sqlAdminLogin string = 'reddog'
 @secure()
 param sqlAdminLoginPassword string = take(newGuid(), 16)
 
+@description('By default all apps scale down to 0. This setting ensures a minimum instance count of 1 for UI and Traefik.')
+param keepUiAppUp bool = true
+
 module containerAppsEnvModule 'modules/capps-env.bicep' = {
   name: '${deployment().name}--containerAppsEnv'
   params: {
@@ -239,6 +242,7 @@ module traefikModule 'modules/container-apps/traefik.bicep' = {
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvModule.outputs.name
+    minReplicas: keepUiAppUp ? 1 : 0
   }
 }
 
@@ -251,6 +255,7 @@ module uiModule 'modules/container-apps/ui.bicep' = {
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvModule.outputs.name
+    minReplicas: keepUiAppUp ? 1 : 0
   }
 }
 

--- a/deploy/bicep/modules/container-apps/traefik.bicep
+++ b/deploy/bicep/modules/container-apps/traefik.bicep
@@ -1,6 +1,8 @@
 param containerAppsEnvName string
 param location string
 
+param minReplicas int = 0
+
 resource cappsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' existing = {
   name: containerAppsEnvName
 }
@@ -44,7 +46,7 @@ resource traefik 'Microsoft.App/containerApps@2022-06-01-preview' = {
         }
       ]
       scale: {
-        minReplicas: 0
+        minReplicas: minReplicas
       }
     }
     configuration: {

--- a/deploy/bicep/modules/container-apps/ui.bicep
+++ b/deploy/bicep/modules/container-apps/ui.bicep
@@ -1,6 +1,8 @@
 param containerAppsEnvName string
 param location string
 
+param minReplicas int = 0
+
 resource cappsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' existing = {
   name: containerAppsEnvName
 }
@@ -44,7 +46,7 @@ resource ui 'Microsoft.App/containerApps@2022-06-01-preview' = {
         }
       ]
       scale: {
-        minReplicas: 0
+        minReplicas: minReplicas
       }
     }
     configuration: {


### PR DESCRIPTION
The UI and Traefik apps take approx 14s to scale from zero, which isn't the best experience.
 
This change lets just those components stay running with 1 minimum replica.

A new parameter has been introduced to toggle between the old and new behaviour.