### PR TITLE
Egress lockdown

### DIFF
--- a/EGRESS-LOCKDOWN.md
+++ b/EGRESS-LOCKDOWN.md
@@ -186,6 +186,8 @@ az network vnet subnet update \
 
 ## Deploy the Environment and Apps
 
+To take advantage of the UDR, we'll deploy the app with a Vnet/Subnet resource ID, Internal Networking enabled and a workload profile configuration. 
+
 ```bash
 ACARG=RedDogACAEgressLockdown-App
 LOC=eastus
@@ -193,7 +195,13 @@ LOC=eastus
 # Create the App Resource Group
 az group create -n $ACARG -l $LOC
 
-az deployment group create -n reddog -g $ACARG -f ./deploy/bicep/main.bicep --parameters vnetSubnetId=$PRIV_ACA_ENV_SUBNET_ID
+az deployment group create -n reddog -g $ACARG -f ./deploy/bicep/main.bicep \
+--parameters \
+vnetSubnetId=$PRIV_ACA_ENV_SUBNET_ID \
+vnetInternal=true \
+workloadProfileName=reddog \
+workloadProfileType=D4 
+
 
 az deployment group show -n reddog -g $ACARG -o json --query properties.outputs.urls.value
 ```
@@ -228,3 +236,7 @@ az network private-dns record-set a add-record \
 --zone-name $ENVIRONMENT_DEFAULT_DOMAIN
 
 ```
+
+## Accessing the Application
+
+To access the reddog UI at the URL you got from the deployment output, you'll need to create a jump server in the vnet that you can use. You can either enable 'Bastion' on the Vnet and then create a VM with no public IP, or you can create a separate subnet that doesnt have the route table attached, and create a VM in that subnet with a public IP you can use to access the network. 

--- a/EGRESS-LOCKDOWN.md
+++ b/EGRESS-LOCKDOWN.md
@@ -1,0 +1,223 @@
+# Egress Lockdown
+
+## Introduction
+
+This doc walks through a sample configuration of a locked down network infrastructure. It will create the Virtual Network, Subnets, Firewall and Route Table to force egress traffic out through the firewall. It also provides the minimum firewall rules needed by Azure Container Apps and the Red Dog application.
+
+> **Note:** If you already have a virutal network configured for egress control through your enterprise egress firewall, you can skip to the rules section and share those with your network admin to setup access before deploying the application.
+
+## Prepare the Vnet
+
+First we'll setup the network infrastructure. We'll keep this in it's on Resource Group to make it easier to delete and redeploy the red dog components later.
+
+```bash
+# Set the Resource Group Name and Region Environment Variables
+RG=RedDogACAEgressLockdown-Infra
+LOC=eastus
+
+# Create Resource Group
+az group create -g $RG -l $LOC
+
+# Set an environment variable for the VNet name
+VNET_NAME=aca-vnet
+
+# Create the Vnet along with the initial subnet for ACA
+az network vnet create \
+-g $RG \
+-n $VNET_NAME \
+--address-prefix 10.140.0.0/16 \
+--subnet-name aca \
+--subnet-prefix 10.140.0.0/27
+
+az network vnet subnet update \
+--resource-group $RG \
+--vnet-name $VNET_NAME \
+--name aca \
+--delegations 'Microsoft.App/environments'
+
+# Adding a subnet for the Azure Firewall
+az network vnet subnet create \
+--resource-group $RG \
+--vnet-name $VNET_NAME \
+--name AzureFirewallSubnet \
+--address-prefix 10.140.1.0/24
+
+# Get the ACA Subnet Resource ID for later use
+PRIV_ACA_ENV_SUBNET_ID=$(az network vnet subnet show -g $RG --vnet-name $VNET_NAME -n aca --query id -o tsv)
+
+```
+
+## Create the Firewall
+
+```bash
+# Create Azure Firewall Public IP
+az network public-ip create -g $RG -n azfirewall-ip --sku "Standard"
+
+# Create Azure Firewall
+az extension add --name azure-firewall
+FIREWALLNAME=reddog-egress
+az network firewall create -g $RG -n $FIREWALLNAME --enable-dns-proxy true
+
+# Configure Firewall IP Config
+az network firewall ip-config create -g $RG -f $FIREWALLNAME -n aca-firewallconfig --public-ip-address azfirewall-ip --vnet-name $VNET_NAME
+```
+
+## Configure the Firewall Rules for ACA and Red Dog
+
+```bash
+# Create list of FQDNs for the rule
+TARGET_FQDNS=('mcr.microsoft.com' \
+'*.data.mcr.microsoft.com' \
+'*.blob.core.windows.net' \
+'packages.microsoft.com' \
+'auth.docker.io' \
+'registry-1.docker.io' \
+'index.docker.io' \
+'dseasb33srnrn.cloudfront.net' \
+'production.cloudflare.docker.com' \
+'archive.ubuntu.com' \
+'security.ubuntu.com' \
+'dl-cdn.alpinelinux.org' \
+'marketplace.azurecr.io' \
+'marketplaceeush.cdn.azcr.io' \
+'ghcr.io' \
+'pkg-containers.githubusercontent.com')
+
+# Create the application rule for ACA Container Registry Access
+az network firewall application-rule create \
+-g $RG \
+-f $FIREWALLNAME \
+--collection-name 'aca-cr' \
+-n 'aca-cr' \
+--source-addresses '*' \
+--protocols 'http=80' 'https=443' \
+--target-fqdns ${TARGET_FQDNS[@]} \
+--action allow --priority 200
+
+
+az network firewall network-rule create \
+-g $RG \
+-f $FIREWALLNAME \
+--collection-name 'reddogfwnr' \
+-n 'svcbus' \
+--protocols 'TCP' \
+--source-addresses '*' \
+--destination-addresses  "ServiceBus" \
+--destination-ports 5671 \
+--action allow --priority 400
+
+az network firewall network-rule create \
+-g $RG \
+-f $FIREWALLNAME \
+--collection-name 'reddogfwnr' \
+-n 'sqltcp' \
+--protocols 'TCP' \
+--source-addresses '*' \
+--destination-addresses  "Sql" \
+--destination-ports 1433 11000-11999
+
+az network firewall network-rule create \
+-g $RG \
+-f $FIREWALLNAME \
+--collection-name 'reddogfwnr' \
+-n 'cosmos' \
+--protocols 'TCP' \
+--source-addresses '*' \
+--destination-addresses  "AzureCosmosDB" \
+--destination-ports 443
+
+az network firewall network-rule create \
+-g $RG \
+-f $FIREWALLNAME \
+--collection-name 'reddogfwnr' \
+-n 'storage' \
+--protocols 'TCP' \
+--source-addresses '*' \
+--destination-addresses  "Storage" \
+--destination-ports 443
+
+az network firewall network-rule create \
+-g $RG \
+-f $FIREWALLNAME \
+--collection-name 'reddogfwnr' \
+-n 'monitor' \
+--protocols 'TCP' \
+--source-addresses '*' \
+--destination-addresses  "AzureMonitor" \
+--destination-ports 443
+```
+
+## Set up the Route Table
+
+```bash
+# Get the public and private IP of the firewall for the routing rules
+FWPUBLIC_IP=$(az network public-ip show -g $RG -n azfirewall-ip --query "ipAddress" -o tsv)
+FWPRIVATE_IP=$(az network firewall show -g $RG -n $FIREWALLNAME --query "ipConfigurations[0].privateIPAddress" -o tsv)
+
+# Create Route Table
+az network route-table create \
+-g $RG \
+-n acadefaultroutes
+
+# Create Default Routes
+az network route-table route create \
+-g $RG \
+--route-table-name acadefaultroutes \
+-n firewall-route \
+--address-prefix 0.0.0.0/0 \
+--next-hop-type VirtualAppliance \
+--next-hop-ip-address $FWPRIVATE_IP
+
+az network route-table route create \
+-g $RG \
+--route-table-name acadefaultroutes \
+-n internet-route \
+--address-prefix $FWPUBLIC_IP/32 \
+--next-hop-type Internet
+
+# Associate Route Table to ACA Subnet
+az network vnet subnet update \
+-g $RG \
+--vnet-name $VNET_NAME \
+-n aca \
+--route-table acadefaultroutes
+```
+
+## Deploy the Environment and Apps
+
+```bash
+az deployment group create -n reddog -g $RG -f ./deploy/bicep/main.bicep --parameters vnetSubnetId=$PRIV_ACA_ENV_SUBNET_ID
+
+az deployment group show -n reddog -g $RG -o json --query properties.outputs.urls.value
+```
+
+## Create the private zone
+
+```bash
+# TODO: Parameterize the env name
+# Get the App FQDN
+ENVIRONMENT_DEFAULT_DOMAIN=$(az containerapp env show --name cae-reddog-rcr4hoxcosure --resource-group ${RG} --query properties.defaultDomain --out tsv)
+
+# Get the App Private IP
+ENVIRONMENT_STATIC_IP=$(az containerapp env show --name cae-reddog-rcr4hoxcosure --resource-group ${RG} --query properties.staticIp --out tsv)
+
+# Create the Private Zone
+az network private-dns zone create \
+--resource-group $RG \
+--name $ENVIRONMENT_DEFAULT_DOMAIN
+
+VNET_ID=$(az network vnet show -g $RG -n $VNET_NAME --query id -o tsv)
+
+az network private-dns link vnet create \
+--resource-group $RG \
+--name $VNET_NAME \
+--virtual-network $VNET_ID \
+--zone-name $ENVIRONMENT_DEFAULT_DOMAIN -e true
+
+az network private-dns record-set a add-record \
+--resource-group $RG \
+--record-set-name "*" \
+--ipv4-address $ENVIRONMENT_STATIC_IP \
+--zone-name $ENVIRONMENT_DEFAULT_DOMAIN
+
+```

--- a/EGRESS-LOCKDOWN.md
+++ b/EGRESS-LOCKDOWN.md
@@ -4,7 +4,7 @@
 
 This doc walks through a sample configuration of a locked down network infrastructure. It will create the Virtual Network, Subnets, Firewall and Route Table to force egress traffic out through the firewall. It also provides the minimum firewall rules needed by Azure Container Apps and the Red Dog application.
 
-> **Note:** If you already have a virutal network configured for egress control through your enterprise egress firewall, you can skip to the rules section and share those with your network admin to setup access before deploying the application.
+> **Note:** If you already have a virutal network configured for egress control through your enterprise egress firewall, you can skip to the rules section and share those with your network admin to setup access before deploying the application. Once the rules are applied, you can skip ahead to the [Deploy the Environment and Apps](#deploy-the-environment-and-apps) section.
 
 ## Prepare the Vnet
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ Traefik is a leading reverse proxy and load balancer that integrates with your e
 
 >A tenth service, Bootstrapper is also executed in a Container App. This service is run once to perform the database creation and is subsequently scaled to 0 after creating the necessary objects in Azure SQL Database.
 
-## Deployment
+## Egress Lockdown Deployment
+
+If you wish to deploy reddog on ACA in a Vnet configured to restrict egress traffic, you can jump to the [Egress Lockdown](./EGRESS-LOCKDOWN.md) guide. This document will walk you through setting up a secured Vnet, or reusing your own, and deploying the application to that secured infrastructure.
+
+## Standard Deployment
 
 To deploy the Reddog services along with the necessary Azure Resources, clone this repo and run the following [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) commands. You will need an Azure subscription where you have permission to create a Resource Group (eg. Contributor). Alternatively you may execute the [deploy.sh](./deploy.sh) script.
 

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -129,6 +129,7 @@ module orderServiceModule 'modules/container-apps/order-service.bicep' = {
   dependsOn: [
     serviceBusModule
     daprPubsub
+    cosmosModule
   ]
   params: {
     location: location
@@ -145,6 +146,7 @@ module makeLineServiceModule 'modules/container-apps/make-line-service.bicep' = 
     redisModule
     daprPubsub
     daprStateMakeline
+    cosmosModule
   ]
   params: {
     location: location
@@ -281,3 +283,6 @@ output urls array = [
   'Makeline Orders (Redmond): https://reddog.${containerAppsEnvModule.outputs.defaultDomain}/makeline/orders/Redmond'
   'Accounting Order Metrics (Redmond): https://reddog.${containerAppsEnvModule.outputs.defaultDomain}/accounting/OrderMetrics?StoreId=Redmond'
 ]
+
+output capsenvname string = containerAppsEnvModule.outputs.name
+output capsenvfqdn string = containerAppsEnvModule.outputs.defaultDomain

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -14,7 +14,7 @@ param blobContainerName string = 'receipts'
 param sqlServerName string = 'sql-${uniqueSuffix}'
 param sqlDatabaseName string = 'reddog'
 param sqlAdminLogin string = 'reddog'
-param vnetSubnetId string
+param vnetSubnetId string = ''
 param workloadProfileName string = 'egresslockdown'
 param workloadProfileType string = 'D4'
 

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -14,6 +14,9 @@ param blobContainerName string = 'receipts'
 param sqlServerName string = 'sql-${uniqueSuffix}'
 param sqlDatabaseName string = 'reddog'
 param sqlAdminLogin string = 'reddog'
+param vnetSubnetId string
+param workloadProfileName string = 'egresslockdown'
+param workloadProfileType string = 'D4'
 
 @secure()
 param sqlAdminLoginPassword string = take(newGuid(), 16)
@@ -25,6 +28,9 @@ module containerAppsEnvModule 'modules/capps-env.bicep' = {
   name: '${deployment().name}--containerAppsEnv'
   params: {
     location: location
+    vnetSubnetId: vnetSubnetId
+    workloadProfileName: workloadProfileName
+    workloadProfileType: workloadProfileType
     containerAppsEnvName: containerAppsEnvName
     logAnalyticsWorkspaceName: logAnalyticsWorkspaceName
     appInsightsName: appInsightsName
@@ -127,6 +133,7 @@ module orderServiceModule 'modules/container-apps/order-service.bicep' = {
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvModule.outputs.name
+    workloadProfileName: workloadProfileName
   }
 }
 
@@ -142,6 +149,7 @@ module makeLineServiceModule 'modules/container-apps/make-line-service.bicep' = 
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvModule.outputs.name
+    workloadProfileName: workloadProfileName
     serviceBusNamespaceName: serviceBusNamespaceName
   }
 }
@@ -157,6 +165,7 @@ module loyaltyServiceModule 'modules/container-apps/loyalty-service.bicep' = {
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvName
+    workloadProfileName: workloadProfileName
     serviceBusNamespaceName: serviceBusNamespaceName
   }
 }
@@ -171,6 +180,7 @@ module receiptGenerationServiceModule 'modules/container-apps/receipt-generation
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvModule.outputs.name
+    workloadProfileName: workloadProfileName
     serviceBusNamespaceName: serviceBusNamespaceName
   }
 }
@@ -184,6 +194,7 @@ module virtualWorkerModule 'modules/container-apps/virtual-worker.bicep' = {
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvModule.outputs.name
+    workloadProfileName: workloadProfileName
   }
 }
 
@@ -196,6 +207,7 @@ module bootstrapperModule 'modules/container-apps/bootstrapper.bicep' = {
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvModule.outputs.name
+    workloadProfileName: workloadProfileName
     sqlDatabaseName: sqlDatabaseName
     sqlServerName: sqlServerModule.outputs.serverName
     sqlAdminLogin: sqlAdminLogin
@@ -214,6 +226,7 @@ module accountingServiceModule 'modules/container-apps/accounting-service.bicep'
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvModule.outputs.name
+    workloadProfileName: workloadProfileName
     serviceBusNamespaceName: serviceBusNamespaceName
     sqlServerName: sqlServerName
     sqlDatabaseName: sqlDatabaseName
@@ -234,6 +247,7 @@ module virtualCustomerModule 'modules/container-apps/virtual-customer.bicep' = {
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvModule.outputs.name
+    workloadProfileName: workloadProfileName
   }
 }
 
@@ -242,6 +256,7 @@ module traefikModule 'modules/container-apps/traefik.bicep' = {
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvModule.outputs.name
+    workloadProfileName: workloadProfileName
     minReplicas: keepUiAppUp ? 1 : 0
   }
 }
@@ -255,6 +270,7 @@ module uiModule 'modules/container-apps/ui.bicep' = {
   params: {
     location: location
     containerAppsEnvName: containerAppsEnvModule.outputs.name
+    workloadProfileName: workloadProfileName
     minReplicas: keepUiAppUp ? 1 : 0
   }
 }

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -15,8 +15,9 @@ param sqlServerName string = 'sql-${uniqueSuffix}'
 param sqlDatabaseName string = 'reddog'
 param sqlAdminLogin string = 'reddog'
 param vnetSubnetId string = ''
-param workloadProfileName string = 'egresslockdown'
-param workloadProfileType string = 'D4'
+param workloadProfileName string = ''
+param workloadProfileType string = ''
+param vnetInternal bool = false
 
 @secure()
 param sqlAdminLoginPassword string = take(newGuid(), 16)
@@ -29,6 +30,7 @@ module containerAppsEnvModule 'modules/capps-env.bicep' = {
   params: {
     location: location
     vnetSubnetId: vnetSubnetId
+    vnetInternal: vnetInternal
     workloadProfileName: workloadProfileName
     workloadProfileType: workloadProfileType
     containerAppsEnvName: containerAppsEnvName
@@ -129,7 +131,6 @@ module orderServiceModule 'modules/container-apps/order-service.bicep' = {
   dependsOn: [
     serviceBusModule
     daprPubsub
-    cosmosModule
   ]
   params: {
     location: location
@@ -146,7 +147,6 @@ module makeLineServiceModule 'modules/container-apps/make-line-service.bicep' = 
     redisModule
     daprPubsub
     daprStateMakeline
-    cosmosModule
   ]
   params: {
     location: location

--- a/deploy/bicep/modules/capps-env.bicep
+++ b/deploy/bicep/modules/capps-env.bicep
@@ -32,14 +32,11 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
 resource containerAppsEnv 'Microsoft.App/managedEnvironments@2022-11-01-preview' = {
   name: containerAppsEnvName
   location: location
-  // sku: {
-  //   name: 'Consumption'
-  // }
-
+  
   properties: {
     vnetConfiguration: {
       infrastructureSubnetId: ((!empty(vnetSubnetId)) ? vnetSubnetId : null)
-      internal: true
+      internal: ((!empty(vnetSubnetId)) ? true : false)
     }
     workloadProfiles: [
       {

--- a/deploy/bicep/modules/capps-env.bicep
+++ b/deploy/bicep/modules/capps-env.bicep
@@ -38,7 +38,7 @@ resource containerAppsEnv 'Microsoft.App/managedEnvironments@2022-11-01-preview'
 
   properties: {
     vnetConfiguration: {
-      infrastructureSubnetId: vnetSubnetId
+      infrastructureSubnetId: ((!empty(vnetSubnetId)) ? vnetSubnetId : null)
       internal: true
     }
     workloadProfiles: [

--- a/deploy/bicep/modules/capps-env.bicep
+++ b/deploy/bicep/modules/capps-env.bicep
@@ -3,6 +3,7 @@ param logAnalyticsWorkspaceName string
 param appInsightsName string
 param location string
 param vnetSubnetId string
+param vnetInternal bool
 param workloadProfileName string
 param workloadProfileType string
 
@@ -32,20 +33,21 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
 resource containerAppsEnv 'Microsoft.App/managedEnvironments@2022-11-01-preview' = {
   name: containerAppsEnvName
   location: location
-  
+
   properties: {
     vnetConfiguration: {
       infrastructureSubnetId: ((!empty(vnetSubnetId)) ? vnetSubnetId : null)
-      internal: ((!empty(vnetSubnetId)) ? true : false)
+      internal: vnetInternal
     }
-    workloadProfiles: [
+    workloadProfiles: ((empty(vnetSubnetId)) ? null : [
       {
         minimumCount: 1
         maximumCount: 10
         name: workloadProfileName
         workloadProfileType: workloadProfileType
       }
-    ]
+    ])
+    
     daprAIInstrumentationKey: appInsights.properties.InstrumentationKey
     appLogsConfiguration: {
       destination: 'log-analytics'

--- a/deploy/bicep/modules/capps-env.bicep
+++ b/deploy/bicep/modules/capps-env.bicep
@@ -2,6 +2,9 @@ param containerAppsEnvName string
 param logAnalyticsWorkspaceName string
 param appInsightsName string
 param location string
+param vnetSubnetId string
+param workloadProfileName string
+param workloadProfileType string
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
   name: logAnalyticsWorkspaceName
@@ -26,13 +29,26 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
-resource containerAppsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' = {
+resource containerAppsEnv 'Microsoft.App/managedEnvironments@2022-11-01-preview' = {
   name: containerAppsEnvName
   location: location
-  sku: {
-    name: 'Consumption'
-  }
+  // sku: {
+  //   name: 'Consumption'
+  // }
+
   properties: {
+    vnetConfiguration: {
+      infrastructureSubnetId: vnetSubnetId
+      internal: true
+    }
+    workloadProfiles: [
+      {
+        minimumCount: 1
+        maximumCount: 10
+        name: workloadProfileName
+        workloadProfileType: workloadProfileType
+      }
+    ]
     daprAIInstrumentationKey: appInsights.properties.InstrumentationKey
     appLogsConfiguration: {
       destination: 'log-analytics'

--- a/deploy/bicep/modules/container-apps/accounting-service.bicep
+++ b/deploy/bicep/modules/container-apps/accounting-service.bicep
@@ -4,6 +4,7 @@ param serviceBusNamespaceName string
 param sqlServerName string
 param sqlDatabaseName string
 param sqlAdminLogin string
+param workloadProfileName string
 
 @secure()
 param sqlAdminLoginPassword string
@@ -21,11 +22,12 @@ resource serviceBusAuthRules 'Microsoft.ServiceBus/namespaces/AuthorizationRules
   parent: serviceBus
 }
 
-resource accountingService 'Microsoft.App/containerApps@2022-03-01' = {
+resource accountingService 'Microsoft.App/containerApps@2022-11-01-preview' = {
   name: 'accounting-service'
   location: location
   properties: {
     managedEnvironmentId: cappsEnv.id
+    workloadProfileName: workloadProfileName
     template: {
       containers: [
         {

--- a/deploy/bicep/modules/container-apps/bootstrapper.bicep
+++ b/deploy/bicep/modules/container-apps/bootstrapper.bicep
@@ -3,6 +3,7 @@ param location string
 param sqlServerName string
 param sqlDatabaseName string
 param sqlAdminLogin string
+param workloadProfileName string
 
 @secure()
 param sqlAdminLoginPassword string
@@ -11,11 +12,12 @@ resource cappsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' existin
   name: containerAppsEnvName
 }
 
-resource bootstrapper 'Microsoft.App/containerApps@2022-06-01-preview' = {
+resource bootstrapper 'Microsoft.App/containerApps@2022-11-01-preview' = {
   name: 'bootstrapper'
   location: location
   properties: {
     managedEnvironmentId: cappsEnv.id
+    workloadProfileName: workloadProfileName
     template: {
       containers: [
         {

--- a/deploy/bicep/modules/container-apps/loyalty-service.bicep
+++ b/deploy/bicep/modules/container-apps/loyalty-service.bicep
@@ -1,6 +1,7 @@
 param containerAppsEnvName string
 param location string
 param serviceBusNamespaceName string
+param workloadProfileName string
 
 resource cappsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' existing = {
   name: containerAppsEnvName
@@ -15,11 +16,12 @@ resource serviceBusAuthRules 'Microsoft.ServiceBus/namespaces/AuthorizationRules
   parent: serviceBus
 }
 
-resource loyaltyService 'Microsoft.App/containerApps@2022-06-01-preview' = {
+resource loyaltyService 'Microsoft.App/containerApps@2022-11-01-preview' = {
   name: 'loyalty-service'
   location: location
   properties: {
     managedEnvironmentId: cappsEnv.id
+    workloadProfileName: workloadProfileName
     template: {
       containers: [
         {

--- a/deploy/bicep/modules/container-apps/make-line-service.bicep
+++ b/deploy/bicep/modules/container-apps/make-line-service.bicep
@@ -1,6 +1,7 @@
 param containerAppsEnvName string
 param location string
 param serviceBusNamespaceName string
+param workloadProfileName string
 
 resource cappsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' existing = {
   name: containerAppsEnvName
@@ -15,11 +16,12 @@ resource serviceBusAuthRules 'Microsoft.ServiceBus/namespaces/AuthorizationRules
   parent: serviceBus
 }
 
-resource makeLineService 'Microsoft.App/containerApps@2022-03-01' = {
+resource makeLineService 'Microsoft.App/containerApps@2022-11-01-preview' = {
   name: 'make-line-service'
   location: location
   properties: {
     managedEnvironmentId: cappsEnv.id
+    workloadProfileName: workloadProfileName
     template: {
       containers: [
         {

--- a/deploy/bicep/modules/container-apps/order-service.bicep
+++ b/deploy/bicep/modules/container-apps/order-service.bicep
@@ -1,15 +1,17 @@
 param containerAppsEnvName string
 param location string
+param workloadProfileName string
 
 resource cappsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' existing = {
   name: containerAppsEnvName
 }
 
-resource orderService 'Microsoft.App/containerApps@2022-06-01-preview' = {
+resource orderService 'Microsoft.App/containerApps@2022-11-01-preview' = {
   name: 'order-service'
   location: location
   properties: {
     managedEnvironmentId: cappsEnv.id
+    workloadProfileName: workloadProfileName
     template: {
       containers: [
         {

--- a/deploy/bicep/modules/container-apps/receipt-generation-service.bicep
+++ b/deploy/bicep/modules/container-apps/receipt-generation-service.bicep
@@ -1,6 +1,7 @@
 param containerAppsEnvName string
 param location string
 param serviceBusNamespaceName string
+param workloadProfileName string
 
 resource cappsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' existing = {
   name: containerAppsEnvName
@@ -15,11 +16,12 @@ resource serviceBusAuthRules 'Microsoft.ServiceBus/namespaces/AuthorizationRules
   parent: serviceBus
 }
 
-resource receiptGenerationService 'Microsoft.App/containerApps@2022-03-01' = {
+resource receiptGenerationService 'Microsoft.App/containerApps@2022-11-01-preview' = {
   name: 'receipt-generation-service'
   location: location
   properties: {
     managedEnvironmentId: cappsEnv.id
+    workloadProfileName: workloadProfileName
     template: {
       containers: [
         {

--- a/deploy/bicep/modules/container-apps/traefik.bicep
+++ b/deploy/bicep/modules/container-apps/traefik.bicep
@@ -1,5 +1,6 @@
 param containerAppsEnvName string
 param location string
+param workloadProfileName string
 
 param minReplicas int = 0
 
@@ -7,11 +8,12 @@ resource cappsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' existin
   name: containerAppsEnvName
 }
 
-resource traefik 'Microsoft.App/containerApps@2022-06-01-preview' = {
+resource traefik 'Microsoft.App/containerApps@2022-11-01-preview' = {
   name: 'reddog'
   location: location
   properties: {
     managedEnvironmentId: cappsEnv.id
+    workloadProfileName: workloadProfileName
     template: {
       containers: [
         {

--- a/deploy/bicep/modules/container-apps/ui.bicep
+++ b/deploy/bicep/modules/container-apps/ui.bicep
@@ -1,5 +1,6 @@
 param containerAppsEnvName string
 param location string
+param workloadProfileName string
 
 param minReplicas int = 0
 
@@ -7,11 +8,12 @@ resource cappsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' existin
   name: containerAppsEnvName
 }
 
-resource ui 'Microsoft.App/containerApps@2022-06-01-preview' = {
+resource ui 'Microsoft.App/containerApps@2022-11-01-preview' = {
   name: 'ui'
   location: location
   properties: {
     managedEnvironmentId: cappsEnv.id
+    workloadProfileName: workloadProfileName
     template: {
       containers: [
         {

--- a/deploy/bicep/modules/container-apps/virtual-customer.bicep
+++ b/deploy/bicep/modules/container-apps/virtual-customer.bicep
@@ -1,15 +1,17 @@
 param containerAppsEnvName string
 param location string
+param workloadProfileName string
 
 resource cappsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' existing = {
   name: containerAppsEnvName
 }
 
-resource virtualCustomers 'Microsoft.App/containerApps@2022-06-01-preview' = {
+resource virtualCustomers 'Microsoft.App/containerApps@2022-11-01-preview' = {
   name: 'virtual-customers'
   location: location
   properties: {
     managedEnvironmentId: cappsEnv.id
+    workloadProfileName: workloadProfileName
     template: {
       containers: [
         {

--- a/deploy/bicep/modules/container-apps/virtual-worker.bicep
+++ b/deploy/bicep/modules/container-apps/virtual-worker.bicep
@@ -1,15 +1,17 @@
 param containerAppsEnvName string
 param location string
+param workloadProfileName string
 
 resource cappsEnv 'Microsoft.App/managedEnvironments@2022-06-01-preview' existing = {
   name: containerAppsEnvName
 }
 
-resource virtualWorker 'Microsoft.App/containerApps@2022-06-01-preview' = {
+resource virtualWorker 'Microsoft.App/containerApps@2022-11-01-preview' = {
   name: 'virtual-worker'
   location: location
   properties: {
     managedEnvironmentId: cappsEnv.id
+    workloadProfileName: workloadProfileName
     template: {
       containers: [
         {


### PR DESCRIPTION
This PR provides a new Egress Lockdown guide for the RedDog on ACA deployment, as well as some updates to the bicep template to enable the deployment of the app into either an egress locked environment or a standard non-locked environment. Users following the original README should have the same experience as they've had previously. Users following the egress locked path will have the steps to create a Vnet, Firewall, UDR and the application deployment.